### PR TITLE
Fix/fail test

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.0",
-    "@valkey/valkey-glide": "^1.3.4"
+    "@valkey/valkey-glide": "^2.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -320,7 +320,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 
   fastify.register(fastifyValkey, {
     addresses: [],
-    requestTimeout: 1000
+    requestTimeout: 250
   })
 
   await t.assert.rejects(fastify.ready())
@@ -335,7 +335,7 @@ test('Should throw when @fastify/valkey is initialized with a namespace and an o
   fastify.register(fastifyValkey, {
     addresses: [],
     namespace: 'fail',
-    requestTimeout: 1000
+    requestTimeout: 250
   })
 
   await t.assert.rejects(fastify.ready())

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,7 +315,7 @@ test('Should be able to register multiple namespaced @fastify/valkey instances',
 test('Should throw when @fastify/valkey is initialized with an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ pluginTimeout: 20000 })
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -320,6 +320,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 
   fastify.register(fastifyValkey, {
     addresses: [],
+    requestTimeout: 500,
     connectionBackoff: {
       numberOfRetries: 0
     }
@@ -337,6 +338,7 @@ test('Should throw when @fastify/valkey is initialized with a namespace and an o
   fastify.register(fastifyValkey, {
     addresses: [],
     namespace: 'fail',
+    requestTimeout: 500,
     connectionBackoff: {
       numberOfRetries: 0
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -320,9 +320,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 
   fastify.register(fastifyValkey, {
     addresses: [],
-    connectionBackoff: {
-      numberOfRetries: 0
-    }
+    requestTimeout: 1000
   })
 
   await t.assert.rejects(fastify.ready())
@@ -337,9 +335,7 @@ test('Should throw when @fastify/valkey is initialized with a namespace and an o
   fastify.register(fastifyValkey, {
     addresses: [],
     namespace: 'fail',
-    connectionBackoff: {
-      numberOfRetries: 0
-    }
+    requestTimeout: 1000
   })
 
   await t.assert.rejects(fastify.ready())

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -318,7 +318,12 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
   const fastify = Fastify({ pluginTimeout: 20000 })
   t.after(() => fastify.close())
 
-  fastify.register(fastifyValkey, { addresses: [] })
+  fastify.register(fastifyValkey, {
+    addresses: [],
+    connectionBackoff: {
+      numberOfRetries: 0
+    }
+  })
 
   await t.assert.rejects(fastify.ready())
 })
@@ -331,7 +336,10 @@ test('Should throw when @fastify/valkey is initialized with a namespace and an o
 
   fastify.register(fastifyValkey, {
     addresses: [],
-    namespace: 'fail'
+    namespace: 'fail',
+    connectionBackoff: {
+      numberOfRetries: 0
+    }
   })
 
   await t.assert.rejects(fastify.ready())

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,12 +315,11 @@ test('Should be able to register multiple namespaced @fastify/valkey instances',
 test('Should throw when @fastify/valkey is initialized with an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify({ pluginTimeout: 20000 })
+  const fastify = Fastify({ pluginTimeout: 30000 })
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {
     addresses: [],
-    requestTimeout: 500,
     connectionBackoff: {
       numberOfRetries: 0
     }
@@ -332,13 +331,12 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 test('Should throw when @fastify/valkey is initialized with a namespace and an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify({ pluginTimeout: 20000 })
+  const fastify = Fastify({ pluginTimeout: 30000 })
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {
     addresses: [],
     namespace: 'fail',
-    requestTimeout: 500,
     connectionBackoff: {
       numberOfRetries: 0
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,7 +315,7 @@ test('Should be able to register multiple namespaced @fastify/valkey instances',
 test('Should throw when @fastify/valkey is initialized with an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify({ pluginTimeout: 20000 })
+  const fastify = Fastify()
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {
@@ -331,7 +331,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 test('Should throw when @fastify/valkey is initialized with a namespace and an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify({ pluginTimeout: 20000 })
+  const fastify = Fastify()
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -329,7 +329,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 test('Should throw when @fastify/valkey is initialized with a namespace and an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ pluginTimeout: 20000 })
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -320,7 +320,9 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 
   fastify.register(fastifyValkey, {
     addresses: [],
-    requestTimeout: 250
+    connectionBackoff: {
+      numberOfRetries: 0
+    }
   })
 
   await t.assert.rejects(fastify.ready())
@@ -335,7 +337,9 @@ test('Should throw when @fastify/valkey is initialized with a namespace and an o
   fastify.register(fastifyValkey, {
     addresses: [],
     namespace: 'fail',
-    requestTimeout: 250
+    connectionBackoff: {
+      numberOfRetries: 0
+    }
   })
 
   await t.assert.rejects(fastify.ready())

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,7 +315,7 @@ test('Should be able to register multiple namespaced @fastify/valkey instances',
 test('Should throw when @fastify/valkey is initialized with an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ pluginTimeout: 20000 })
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, { addresses: [] })
@@ -326,7 +326,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 test('Should throw when @fastify/valkey is initialized with a namespace and an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ pluginTimeout: 20000 })
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {


### PR DESCRIPTION
This pull request updates the `@valkey/valkey-glide` dependency to the latest major version and modifies test configurations to include a `pluginTimeout` option for `Fastify` instances.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L48-R48): Updated `@valkey/valkey-glide` dependency from version `^1.3.4` to `^2.0.1` to ensure compatibility with the latest features and fixes.

Test configuration changes:

* [`test/index.test.js`](diffhunk://#diff-af95cb6f5f65fe70216ddce70325e785438d5aaff956a0666ebf46ef6402f526L318-R318): Added `pluginTimeout: 20000` to `Fastify` instances in two test cases to improve test reliability when registering plugins with potentially long initialization times. [[1]](diffhunk://#diff-af95cb6f5f65fe70216ddce70325e785438d5aaff956a0666ebf46ef6402f526L318-R318) [[2]](diffhunk://#diff-af95cb6f5f65fe70216ddce70325e785438d5aaff956a0666ebf46ef6402f526L329-R329)