### PR TITLE
fix: test fail with plugin timeout 

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -315,10 +315,10 @@ test('Should be able to register multiple namespaced @fastify/valkey instances',
 test('Should throw when @fastify/valkey is initialized with an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ pluginTimeout: 20000 })
   t.after(() => fastify.close())
 
-  fastify.register(fastifyValkey, { addresses: [], requestTimeout: 250 })
+  fastify.register(fastifyValkey, { addresses: [] })
 
   await t.assert.rejects(fastify.ready())
 })
@@ -326,7 +326,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
 test('Should throw when @fastify/valkey is initialized with a namespace and an option that makes valkey throw', async (t) => {
   t.plan(1)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ pluginTimeout: 20000 })
   t.after(() => fastify.close())
 
   fastify.register(fastifyValkey, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -318,7 +318,7 @@ test('Should throw when @fastify/valkey is initialized with an option that makes
   const fastify = Fastify()
   t.after(() => fastify.close())
 
-  fastify.register(fastifyValkey, { addresses: [] })
+  fastify.register(fastifyValkey, { addresses: [], requestTimeout: 250 })
 
   await t.assert.rejects(fastify.ready())
 })


### PR DESCRIPTION
This pull request is trying to fix the inconsistence in the test on macOS with node 22.
This is happening when Glide client is initialises with an option that makes it throw an error.