### PR TITLE
chore: update ci setup, style and checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches: 
-    - main
+    branches:
+      - main
     paths-ignore:
       - 'docs/**'
       - '*.md'
@@ -11,17 +11,17 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
-      
+
 permissions:
   contents: read
-  
+
 jobs:
   linter:
     name: Lint Code
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -31,16 +31,17 @@ jobs:
           node-version: lts/*
           check-latest: true
 
-
       - name: Install dependencies
-        run: npm install
+        run: npm install --ignore-scripts
 
       - name: Run linter
         run: npm run lint
 
   test:
-    name: OS ${{ matrix.os }} Node.js ${{ matrix.node }}
+    name: Test
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         node: ['20', 'lts/*', 'current']
@@ -61,11 +62,11 @@ jobs:
           brew services start valkey
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
-      - name: Set up Node.js ${{ matrix.node }}
+      - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}


### PR DESCRIPTION
This pull request updates the continuous integration workflow configuration to improve security and reliability. The main changes include upgrading the GitHub Actions checkout version, modifying dependency installation to prevent running install scripts, and refining job naming and permissions.

**CI workflow improvements:**

* Upgraded the `actions/checkout` step from version 4 to version 5 in both the build and test jobs to use the latest features and security fixes. (`.github/workflows/ci.yml`) [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL24-R24) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL64-R65)
* Changed the dependency installation command to `npm install --ignore-scripts` to prevent execution of potentially unsafe lifecycle scripts during CI runs. (`.github/workflows/ci.yml`)

**Job configuration updates:**

* Updated the test job name to "Test" and added explicit `contents: read` permissions for improved clarity and security. (`.github/workflows/ci.yml`)